### PR TITLE
Add webserver for instant URL display - "Tohora"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,9 @@ To use automatic backlight switching you’ll need to configure a few service va
 
 The `BACKLIGHT_ON` and `BACKLIGHT_OFF` variables accept standard cron syntax; take a look at https://crontab.guru if you’re not familiar. For more instructions check out [our blog post](https://www.balena.io/blog/automate-the-backlight-timer-on-your-balenadash-display/).
 
+## Switching URLs quickly using your web browser or Slack
+
+Your balenaDash device is also running a small webserver on port 80.  The screen will show the URL configured at `WPE_URL` normally, but the webserver allows you to put other URLs on screen quickly and easily.  If you tell balenaCloud to expose your device's public URL, then you can even control it with Slack (or `curl`, or anything that can use webhooks).  [More details](https://github.com/mozz100/tohora/blob/master/README.md)
+
+
 ### For a complete tutorial on how to use balenaDash, please check out our blog post at [https://www.balena.io/blog/make-a-web-frame-with-raspberry-pi-in-30-minutes/](https://www.balena.io/blog/make-a-web-frame-with-raspberry-pi-in-30-minutes/) 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     restart: always
     build: ./wpe
     privileged: true
+    ports:
+      - 80:80
   scheduler:
     restart: always
     build: ./scheduler

--- a/wpe/Dockerfile
+++ b/wpe/Dockerfile
@@ -7,3 +7,9 @@ COPY wpe-init /wpe-init
 RUN chmod +x wpe-init
 
 CMD [ "/wpe-init" ]
+
+ENV TOHORA_VERSION=0.3.0
+RUN wget -O tohora.tgz \
+    "https://github.com/mozz100/tohora/releases/download/v0.3.0/tohora_"$TOHORA_VERSION"_Linux_armv5.tar.gz" \
+    && tar xzf tohora.tgz \
+    && rm tohora.tgz

--- a/wpe/Dockerfile
+++ b/wpe/Dockerfile
@@ -8,8 +8,8 @@ RUN chmod +x wpe-init
 
 CMD [ "/wpe-init" ]
 
-ENV TOHORA_VERSION=0.3.0
+ENV TOHORA_VERSION=0.3.1
 RUN wget -O tohora.tgz \
-    "https://github.com/mozz100/tohora/releases/download/v0.3.0/tohora_"$TOHORA_VERSION"_Linux_armv5.tar.gz" \
+    "https://github.com/mozz100/tohora/releases/download/v"$TOHORA_VERSION"/tohora_"$TOHORA_VERSION"_Linux_armv5.tar.gz" \
     && tar xzf tohora.tgz \
     && rm tohora.tgz

--- a/wpe/Dockerfile
+++ b/wpe/Dockerfile
@@ -8,7 +8,7 @@ RUN chmod +x wpe-init
 
 CMD [ "/wpe-init" ]
 
-ENV TOHORA_VERSION=0.3.1
+ENV TOHORA_VERSION=0.3.2
 RUN wget -O tohora.tgz \
     "https://github.com/mozz100/tohora/releases/download/v"$TOHORA_VERSION"/tohora_"$TOHORA_VERSION"_Linux_armv5.tar.gz" \
     && tar xzf tohora.tgz \

--- a/wpe/wpe-init
+++ b/wpe/wpe-init
@@ -5,4 +5,6 @@ udevadm trigger
 
 fbcp &
 
-WPE_BCMRPI_TOUCH=1 WPELauncher $WPE_URL
+WPE_BCMRPI_TOUCH=1 WPELauncher $WPE_URL &
+
+./tohora 80 WPELauncher


### PR DESCRIPTION
This came out of a [forum discussion](
https://forums.balena.io/t/balenadash-how-to-change-url-dynamically/5371) about balenaDash. @chrisys mentioned it was worth submitting a PR :-)

This PR adds a small webserver to enable other URLs to be instantly shown on top of the "base" URL, and cleared off.  We're using it in our office, and really liking it.  Our balenaDash can now display a URL under control from a web browser, Slack, or a cron job.

I've blogged about this here: https://www.rmorrison.net/mnemozzyne/2019/03/07/tohora-instant-control-balenadash/

Tohora is open source (https://github.com/mozz100/tohora) - I've set up a build for it and just included the binary here.