### PR TITLE
scheduler: Enable setting timezone

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,5 +1,7 @@
 FROM balenalib/raspberrypi3-alpine
 
+RUN install_packages tzdata
+
 COPY scripts /usr/src/
 RUN chmod +x /usr/src/*.sh
 

--- a/scheduler/scripts/start.sh
+++ b/scheduler/scripts/start.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+if [ -n "${TIMEZONE}" ]; then
+  echo "Setting timezone to ${TIMEZONE}"
+  cp "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime \
+  && echo "${TIMEZONE}" >  /etc/timezone \
+  || echo "WARNING: couldn't set this timezone."
+fi
+
 if [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
 then
   (crontab -l; echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -


### PR DESCRIPTION
Following the method outlined at https://wiki.alpinelinux.org/wiki/Setting_the_timezone
The timezone is set by the `TIMEZONE` service var, the usual
`Europe/London` format

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>