### PR TITLE
Add check for ENABLE_BACKLIGHT_TIMER in scheduler, fix #19

### DIFF
--- a/scheduler/scripts/start.sh
+++ b/scheduler/scripts/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
+if [ ! -z ${ENABLE_BACKLIGHT_TIMER+x} ] && [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
 then
   (crontab -l; echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -
   (crontab -l; echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh") | crontab -


### PR DESCRIPTION
I added a check for `ENABLE_BACKLIGHT_TIMER` to actually exist.