### PR TITLE
Check for scheduler variable, fix custom WPE_URL

### DIFF
--- a/scheduler/scripts/start.sh
+++ b/scheduler/scripts/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
+if [ ! -z ${ENABLE_BACKLIGHT_TIMER+x} ] && [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
 then
   (crontab -l; echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -
   (crontab -l; echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh") | crontab -

--- a/wpe/wpe-init
+++ b/wpe/wpe-init
@@ -33,13 +33,11 @@ if [[ ! -z ${GALLERY_URL} ]]
   then
     echo "Loading gallery"
     WPE_URL="file:///var/lib/public_html/index.html"
-
-    # wait for it
-    sleep 5
 fi
 
 if [[ ! -z ${WPE_URL+x} ]]
   then
+    sleep 5
     wget --post-data "url=$WPE_URL" http://localhost:8080/launch/
 fi
 


### PR DESCRIPTION
I implemented a check if the scheduler set variable exists.
I also moved the `sleep 5` in `wpe-init` to the part where the script sets the url in Tohora thus fixing the problem of the script sending the wget too early.

Fix #19 #39.