### PR TITLE
scheduler: add HDMI switching

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,5 +1,7 @@
 FROM balenalib/raspberrypi3-alpine
 
+RUN apk --no-cache add libcec
+
 COPY scripts /usr/src/
 RUN chmod +x /usr/src/*.sh
 

--- a/scheduler/scripts/backlight_off.sh
+++ b/scheduler/scripts/backlight_off.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-echo -n 1 > /sys/class/backlight/rpi_backlight/bl_power
+
+output=$(tvservice -s)
+
+if [[ $output =~ "0x400000 [LCD]" ]]; then
+  echo -n 1 > /sys/class/backlight/rpi_backlight/bl_power
+else
+  echo standby 0 | cec-client -s > /dev/null
+fi

--- a/scheduler/scripts/backlight_on.sh
+++ b/scheduler/scripts/backlight_on.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-echo -n 0 > /sys/class/backlight/rpi_backlight/bl_power
+
+output=$(tvservice -s)
+
+if [[ $output =~ "0x400000 [LCD]" ]]; then
+  echo -n 0 > /sys/class/backlight/rpi_backlight/bl_power
+else
+  echo as 0 | cec-client -s > /dev/null
+fi

--- a/scheduler/scripts/start.sh
+++ b/scheduler/scripts/start.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
+
 if [ ! -z ${ENABLE_BACKLIGHT_TIMER+x} ] && [ "$ENABLE_BACKLIGHT_TIMER" -eq "1" ]
 then
-  (crontab -l; echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh") | crontab -
-  (crontab -l; echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh") | crontab -
+  (
+    crontab -l
+    echo "${BACKLIGHT_ON:-0 8 * * *} /usr/src/backlight_on.sh"
+    echo "${BACKLIGHT_OFF:-0 23 * * *} /usr/src/backlight_off.sh"
+  ) | crontab -
 fi
 
 crond -f


### PR DESCRIPTION
Add ability to switch HDMI connected displays with the scheduler as well.
Maybe we should rename the variables from `BACKLIGHT` to `DISPLAY`.

My RPi display is not usable currently. Is somebody willing to test it with this change?